### PR TITLE
[FEAT] 회원가입 시 이메일인증 로직 구현

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/BE/src/main/java/com/myapp/warmwave/domain/email/dto/RequestEmailAuthDto.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/email/dto/RequestEmailAuthDto.java
@@ -1,0 +1,13 @@
+package com.myapp.warmwave.domain.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestEmailAuthDto {
+    String email;
+    String authToken;
+}

--- a/BE/src/main/java/com/myapp/warmwave/domain/email/entity/EmailAuth.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/email/entity/EmailAuth.java
@@ -1,0 +1,36 @@
+package com.myapp.warmwave.domain.email.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "TB_EMAIL_AUTH")
+public class EmailAuth {
+
+    private static final Long EMAIL_TOKEN_EXPIRE_TIME = 10L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String email;
+    private String authToken;
+    private Boolean expired;    // 이메일 인증 토큰 만료여부
+    private LocalDateTime expirationDate;   // 이메일 토큰 만료 시간
+
+    public EmailAuth(Long id, String email, String authToken, Boolean expired, LocalDateTime expirationDate) {
+        this.id = id;
+        this.email = email;
+        this.authToken = authToken;
+        this.expired = expired;
+        this.expirationDate = LocalDateTime.now().plusMinutes(EMAIL_TOKEN_EXPIRE_TIME);
+    }
+
+    public void usedToken() {
+        this.expired = true;
+    }
+}

--- a/BE/src/main/java/com/myapp/warmwave/domain/email/repository/EmailAuthRepository.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/email/repository/EmailAuthRepository.java
@@ -1,0 +1,16 @@
+package com.myapp.warmwave.domain.email.repository;
+
+import com.myapp.warmwave.domain.email.entity.EmailAuth;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
+
+    @Query("SELECT e FROM EmailAuth e WHERE e.email = :email AND e.authToken = :authToken AND e.expirationDate >= :currentTime AND e.expired = false")
+    Optional<EmailAuth> findValidAuthByEmail(@Param("email") String email, @Param("authToken") String authToken, @Param("currentTime") LocalDateTime currentTime);
+
+}

--- a/BE/src/main/java/com/myapp/warmwave/domain/email/service/EmailService.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/email/service/EmailService.java
@@ -1,0 +1,34 @@
+package com.myapp.warmwave.domain.email.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Service;
+
+@Service
+@EnableAsync
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+
+    @Async
+    public void send(String email, String authToken) {
+        try {
+
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(email);
+            message.setSubject("WarmWave 회원가입 이메일 인증");
+
+            String text = "WarmWave 가입해 주셔서 감사합니다. 아래 링크를 클릭해서 이메일 주소를 인증하세요\n\n";
+            text += "http://localhost:8080/api/users/confirm-email?email=" + email + "&authToken=" + authToken;
+            message.setText(text);
+
+            javaMailSender.send(message);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/BE/src/main/java/com/myapp/warmwave/domain/user/controller/UserController.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.myapp.warmwave.domain.user.controller;
 
+import com.myapp.warmwave.domain.email.dto.RequestEmailAuthDto;
 import com.myapp.warmwave.domain.user.dto.*;
 import com.myapp.warmwave.domain.user.service.UserService;
 import jakarta.validation.Valid;
@@ -20,15 +21,29 @@ public class UserController {
 
     // 기관회원가입
     @PostMapping("/register/institution")
-    public ResponseEntity<Long> register(@RequestBody RequestInstitutionJoinDto dto) {
+    public ResponseEntity<ResponseUserJoinDto> register(@RequestBody RequestInstitutionJoinDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.joinInstitution(dto));
     }
 
     // 개인회원가입
     @PostMapping("/register/individual")
-    public ResponseEntity<Long> signup(@Valid @RequestBody RequestIndividualJoinDto dto) {
+    public ResponseEntity<ResponseUserJoinDto> signup(@Valid @RequestBody RequestIndividualJoinDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.joinIndividual(dto));
     }
+
+    // 이메일 인증
+    @GetMapping("/confirm-email")   //인증 URL이 담긴 이메일을 전송받은 사용자가 URL 클릭 시 해당 URI로 매핑
+    public ResponseEntity<String> confirmEmail(@ModelAttribute RequestEmailAuthDto requestDto) {
+        userService.confirmEmail(requestDto);
+        return ResponseEntity.status(HttpStatus.OK).body("인증이 완료되었습니다.");
+    }
+
+//    // 일반 로그인
+//    @PostMapping("/login")
+//    public ResponseEntity<ResponseUserLoginDto> login(@RequestBody RequestUserLoginDto requestDto) {
+//        ResponseUserLoginDto responseDto = userService.loginUser(requestDto);
+//        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+//    }
 
     // 전체 기관 회원 조회
     @GetMapping("/institution")

--- a/BE/src/main/java/com/myapp/warmwave/domain/user/dto/RequestInstitutionJoinDto.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/user/dto/RequestInstitutionJoinDto.java
@@ -4,23 +4,28 @@ import com.myapp.warmwave.common.Role;
 import com.myapp.warmwave.domain.address.entity.Address;
 import com.myapp.warmwave.domain.user.entity.Institution;
 import com.myapp.warmwave.domain.user.service.UserService;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-@Getter
+@Data
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor
 public class RequestInstitutionJoinDto {
+
+    @NotBlank(message = "email은 필수 입력입니다.")
+    @Email
     private String email;
 
+    @NotBlank(message = "password는 필수 입력입니다.")
     private String password;
 
+    @NotBlank(message = "기관이름은 필수 입력입니다.")
     private String institutionName;
 
+    @NotBlank(message = "사업자 등록번호는 필수 입력입니다.")
     private String registerNum;
 
     // 전체 주소
@@ -45,6 +50,7 @@ public class RequestInstitutionJoinDto {
                 .temperature(0F)
                 .profileImg(UserService.DEFAULT_PROFILE_IMG_INST)
                 .role(Role.INSTITUTION)
+                .emailAuth(false)   // 이메일 인증여부 추가
                 .isApprove(Boolean.FALSE)
                 .build();
     }

--- a/BE/src/main/java/com/myapp/warmwave/domain/user/dto/RequestUserLoginDto.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/user/dto/RequestUserLoginDto.java
@@ -1,0 +1,13 @@
+package com.myapp.warmwave.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestUserLoginDto {
+    private String email;
+    private String password;
+}

--- a/BE/src/main/java/com/myapp/warmwave/domain/user/dto/ResponseUserJoinDto.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/user/dto/ResponseUserJoinDto.java
@@ -1,0 +1,21 @@
+package com.myapp.warmwave.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Builder
+public class ResponseUserJoinDto {
+
+    private Long id;
+    private String email;
+    private String authToken;
+
+    public ResponseUserJoinDto(Long id, String email, String authToken) {
+        this.id = id;
+        this.email = email;
+        this.authToken = authToken;
+    }
+}

--- a/BE/src/main/java/com/myapp/warmwave/domain/user/dto/ResponseUserLoginDto.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/user/dto/ResponseUserLoginDto.java
@@ -1,0 +1,14 @@
+package com.myapp.warmwave.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseUserLoginDto {
+    private Long id;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/BE/src/main/java/com/myapp/warmwave/domain/user/entity/User.java
+++ b/BE/src/main/java/com/myapp/warmwave/domain/user/entity/User.java
@@ -39,11 +39,11 @@ public abstract class User extends BaseEntity {
 
     private Float temperature;
 
-//    private Boolean emailAuth;  // 이메일 인증 여부(회원가입 후 진행)
+    private Boolean emailAuth;  // 이메일 인증 여부(회원가입 후 진행)
 
-//    public void emailVerified() {
-//        this.emailAuth = true;
-//    }
+    public void emailVerified() {
+        this.emailAuth = true;
+    }
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ADDRESS_ID")

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -15,6 +15,17 @@ spring:
       enabled: true
     restart:
       enabled: true
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_ADDRESS}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+          auth: true
 
 kakao:
   rest:


### PR DESCRIPTION
<!-- Assignees는 본인, Reviewrs는 팀원 선택 -->

## #️⃣연관된 이슈

> #7 

## 📝작업 내용

> 회원가입 시 인증 링크를 발송하고 이메일 인증을 진행하는 로직 구현
![image](https://github.com/LikeLion-3/donationProject/assets/109578096/925b2f6b-b25e-435b-bf07-460ea0de8410)

>  어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 스크린샷 (선택)
![image](https://github.com/LikeLion-3/donationProject/assets/109578096/87b78698-09c7-44ef-a587-2f9680e535c2)

## 💬리뷰 요구사항(선택)

> Email Entity DB에 추가해주세요! 40d3559d5e3047737fa276219be9c261924ec95a
> 이메일 dependency 추가되었습니다. c719079bc9aadffe718a09ae36d71fd8a7ba3038
> 이메일 인증 발송을 위한 application.yml 환경변수 설정은 노션에 있습니다 c5cd8b5ed91532a30cf160ea98472fe33aa7036c
> User Entity에도 이메일인증여부 column 추가되었습니다 944a366c39b253d883491077fda7d7e91f821d5c

## 체크리스트
- [x] Reviewrs를 설정했습니다
