### PR TITLE
Feature/#127

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 
 ### Gradle ###
 .gradle
+
+### Dump file ###
+dump.rdb
+

--- a/BE/src/main/java/com/myapp/warmwave/common/jwt/JwtAuthFilter.java
+++ b/BE/src/main/java/com/myapp/warmwave/common/jwt/JwtAuthFilter.java
@@ -18,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import static com.myapp.warmwave.common.exception.CustomExceptionCode.EXPIRED_JWT;
@@ -36,29 +37,43 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     // shouldNotFilter()는 OncePerRequestFilter의 상위 클래스에 정의된 메서드, 필터로 체크하지 않을 경로나 메서드 등을 지정하기 위해서 사용
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        List<String> excludePatterns;
 
         // Preflight(Ajax 통신 실제 요청을 보내기 전에 OPTIONS 메서드를 사용하여 서버에 대한 정보를 요청) 요청은 체크하지 않음
         if (request.getMethod().equals("OPTIONS")) {
             return true;
         }
-        String[] excludePath = {
-                // 로그인 경로의 호출은 체크하지 않음
-                "/api/users/login",
-                // 이메일중복체크 경로의 호출은 체크하지 않음
-                "/api/users/register/checkEmail",
-                // 닉네임중복체크 경로의 호출은 체크하지 않음
-                "/api/users/register/checkNickname",
-                // 기관회원가입 경로의 호출은 체크하지 않음
-                "/api/users/register/institution",
-                // 개인회원가입 경로의 호출은 체크하지 않음
-                "/api/users/register/individual",
-                // 이메일 링크 인증 경로의 호출은 체크하지 않음
-                "/api/users/confirm-email",
-        };
 
-        String path = request.getRequestURI();
+        if (request.getMethod().equals("GET")) {
+            excludePatterns = List.of(
+                    // 아티클 목록 조회, 단일 조회의 경우 필터에서 체크하지 않음
+                    "/api/articles/**",
+                    // 커뮤니티 목록 조회, 단일 조회의 경우 필터에서 체크하지 않음
+                    "/api/communities/**",
+                    // 이메일 링크 인증 경로의 호출은 체크하지 않음
+                    "/api/users/confirm-email"
+            );
+            return excludePatterns.stream().anyMatch(path::startsWith);
+        }
 
-        return Arrays.stream(excludePath).anyMatch(path::startsWith);
+        if (request.getMethod().equals("POST")) {
+            excludePatterns = List.of(
+                    // 로그인 경로의 호출은 체크하지 않음.
+                    "/api/users/login",
+                    // 이메일중복체크 경로의 호출은 체크하지 않음.
+                    "/api/users/register/checkEmail",
+                    // 닉네임중복체크 경로의 호출은 체크하지 않음
+                    "/api/users/register/checkNickname",
+                    // 기관회원가입 경로의 호출은 체크하지 않음
+                    "/api/users/register/institution",
+                    // 개인회원가입 경로의 호출은 체크하지 않음
+                    "/api/users/register/individual"
+            );
+            return excludePatterns.stream().anyMatch(path::startsWith);
+        }
+
+        return false;
     }
 
     @Override

--- a/BE/src/main/java/com/myapp/warmwave/config/security/SecurityConfig.java
+++ b/BE/src/main/java/com/myapp/warmwave/config/security/SecurityConfig.java
@@ -47,10 +47,8 @@ public class SecurityConfig {
                                         "/", "/api/users/login", "/api/users/register/**",
                                         "/api/articles/today", "/api/main/count", "/api/users/confirm-email",
                                         "/ws/**", "/api/user/refresh"
-                                )
-                                .permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/articles/**")
-                                .permitAll()
+                                ).permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/articles/**", "/api/communities/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #127 

## 📝작업 내용

> JwtAuthFilter 에서 핉터링 하지 않을 엔드포인트 '/api/articles/**'(method: get), '/api/communities/**'(method: get) 를 추가하는 작업을 진행해주었습니다. 시큐리티에서도 따로 필터링 되지 않도록 requestMatchers() 메소드를 통해 해당 엔드포인트 등록해주었습니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## 체크리스트
- [ ] Reviewrs를 설정했습니다
